### PR TITLE
fix the lock target

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,10 +7,12 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1655487772,
-        "narHash": "sha256-KdVs9RZfjV3QCoLBW1FUxtM44G8Mgb4ME1uEx4lK/ek=",
-        "type": "git",
-        "url": "file:///home/pachums/Repos/POP"
+        "lastModified": 1655392824,
+        "narHash": "sha256-xJMg0EpqvRQPEEgetdEMRqN/w9atctpg4fMtEfro6Tk=",
+        "owner": "divnix",
+        "repo": "POP",
+        "rev": "b458b94c32d28e1c518805e23c9948357d38e6ba",
+        "type": "github"
       },
       "original": {
         "owner": "divnix",


### PR DESCRIPTION
• Updated input 'POP':
    'git+file:///home/pachums/Repos/POP' (2022-06-17)
  → 'github:divnix/POP/b458b94c32d28e1c518805e23c9948357d38e6ba' (2022-06-16)